### PR TITLE
patch 13.24 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VakScript - Spaceglider for League of Legends (13.22+)
+# VakScript - Spaceglider for League of Legends (13.24+)
 
 Tool to automate kiting without any attack speed limit, game mode, or entity.
 The main purpose is help AD Carry players, not limited to any other role.

--- a/vakscript/data.py
+++ b/vakscript/data.py
@@ -6,7 +6,6 @@ TODO:
     - bonus_attack_speed offset in offsets.ini is wrong
 """
 
-# Patch 13.22
 class Offsets:
     offsets_file = configparser.ConfigParser()
     offsets_file.read("offsets.ini")

--- a/vakscript/offsets.ini
+++ b/vakscript/offsets.ini
@@ -1,14 +1,14 @@
 [version]
-script_version = '13.23.1'
+script_version = '13.24'
 [offsets]
-local_player: 0x22118D8
-game_time: 0x21FE6F8
-view_proj_matrix: 0x225B2C0
-champion_list: 0x21F3FE0
-minion_list: 0x21F6F40
-turret_list: 0x21FD970
+game_time: 0x2226D48
+local_player: 0x223A0B8
+champion_list: 0x221C620
+minion_list: 0x221F590
+turret_list: 0x2225FC0
+view_proj_matrix: 0x2284710
 obj_name: 0x38A8
-obj_lvl: 0x4028
+obj_lvl: 0x4048
 obj_team: 0x3C
 obj_gold: 0x2138
 obj_health: 0x1088
@@ -18,7 +18,7 @@ obj_magic_resist: 0x16E4
 obj_base_attack: 0x16B4
 obj_bonus_attack: 0x1620
 obj_bonus_as: 0x1684
-obj_magic_damage: 0x15E8
+obj_magic_damage: 0x1630
 obj_attack_range: 0x16FC
 obj_spawn_count: 0x358
 obj_targetable: 0xEE0


### PR DESCRIPTION
Updated offsets for 13.24
Offsets that was changed in this PR is 100% correct (+ buff, inventory, attack, health and name offsets), don't know about others.